### PR TITLE
Event target

### DIFF
--- a/src/fake-xml-http-request.js
+++ b/src/fake-xml-http-request.js
@@ -16,6 +16,7 @@ var _Event = function Event(type, bubbles, cancelable, target) {
   this.bubbles = bubbles;
   this.cancelable = cancelable;
   this.target = target;
+  this.currentTarget = target;
 };
 
 _Event.prototype = {

--- a/src/fake-xml-http-request.js
+++ b/src/fake-xml-http-request.js
@@ -375,10 +375,10 @@ var FakeXMLHttpRequestProto = {
     this.readyState = state;
 
     if (typeof this.onreadystatechange == "function") {
-      this.onreadystatechange(new _Event("readystatechange"));
+      this.onreadystatechange(new _Event("readystatechange", false, false, this));
     }
 
-    this.dispatchEvent(new _Event("readystatechange"));
+    this.dispatchEvent(new _Event("readystatechange", false, false, this));
 
     if (this.readyState == FakeXMLHttpRequest.DONE) {
       this.dispatchEvent(new _Event("load", false, false, this));


### PR DESCRIPTION
1. **Set currentTarget on Events**
When listening for events (e.g. `readystatechange`) some libraries expect `event.currentTarget` to be set to the XHR, as well as `event.target`. Since the `readystatechange` event doesn't bubble, the `target` and `currentTarget` will always be the same.

2. **Set the target for `readystatechange` events**
Ensure we can access the XHR via target/currentTarget when listening to
the `readystatechange` event.
